### PR TITLE
Fix segfault when bind or listen fails

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -795,15 +795,13 @@ int server_listen(uint16_t port) {
 #endif
 
   if (uv_tcp_bind(ecewo_server.server, (const struct sockaddr *)&addr, flags) != 0) {
-    free(ecewo_server.server);
-    ecewo_server.server = NULL;
+    uv_close((uv_handle_t *)ecewo_server.server, on_server_closed);
     LOG_ERROR("Failed to bind to port %" PRIu16 " (may be in use)", port);
     return SERVER_BIND_FAILED;
   }
 
   if (uv_listen((uv_stream_t *)ecewo_server.server, LISTEN_BACKLOG, on_connection) != 0) {
-    free(ecewo_server.server);
-    ecewo_server.server = NULL;
+    uv_close((uv_handle_t *)ecewo_server.server, on_server_closed);
     LOG_ERROR("Failed to listen on port %" PRIu16, port);
     return SERVER_LISTEN_FAILED;
   }


### PR DESCRIPTION
 When `uv_tcp_bind()` or `uv_listen()` fails, the server handle is freed directly with `free()`. However, at this point `uv_tcp_init()` has already registered the handle with the libuv event loop.

  When the program exits, `server_cleanup()` runs via `atexit` and libuv attempts to walk/close handles that include the already-freed server handle, causing a segmentation fault.

The fix replaces `free()` with `uv_close()`, which properly unregisters the handle from the event loop before freeing. The existing `on_server_closed` callback handles the actual cleanup.
