### PR TITLE
Fix bind failure on macOS due to unsupported UV_TCP_REUSEPORT

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -789,7 +789,7 @@ int server_listen(uint16_t port) {
   const char *is_test = getenv("ECEWO_TEST_MODE");
   unsigned int flags = 0;
 
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(__APPLE__)
   if (!is_test || strcmp(is_test, "1") != 0)
     flags = UV_TCP_REUSEPORT;
 #endif


### PR DESCRIPTION
`UV_TCP_REUSEPORT` is currently enabled on all non-Windows platforms, but libuv only supports this flag on Linux 3.9+, DragonFlyBSD 3.6+, FreeBSD 12.0+, Solaris 11.4, and AIX 7.2.5+.

On macOS, `uv_tcp_bind()` returns `UV_ENOTSUP`, causing the server to fail to start even when the port is available.

The fix excludes macOS from the `UV_TCP_REUSEPORT` code path.

https://docs.libuv.org/en/v1.x/tcp.html#c.uv_tcp_flags